### PR TITLE
Bump, push, and document

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,4 @@
+[bumpversion]
+current_version = 1.0.4
+
+[bumpversion:file:VERSION]

--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - feature/pipeline
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
@@ -10,12 +11,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Set Docker image version
-        run: cat VERSION >> $VERSION
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
         with:
           username: away168
           password: ${{ secrets.DOCKER_AWAY168 }}
-          repository: away168/rps
-          tags: away168/rps:${VERSION}
+      - name: Push to Docker Hub
+        run: ./scripts/docker-build.sh

--- a/README.md
+++ b/README.md
@@ -17,3 +17,33 @@ Dockerfile will create a docker image of the Flask App /RPS-App
 `RPS_USER` - this is username that gets displayed
 `RPS_VERSION` - just a version number that gets added to v0.1.2+
 `RPS_WEBPORT` - if specified determines which port the app runs.  
+
+## Development
+The `VERSION` file at the base of this repo contains the semver version number for the container that will be built by `./scripts/docker-build.sh`. This script will run via GitHub Actions whenever the `master` branch is pushed to GitHub. You can run it manually to build and push the `away168/rps` container like so:
+
+```shell
+$ ./scripts/docker-build.sh
+```
+
+For convenience, you can use the script `./scripts/bump-version.sh` to update the `VERSION` file. This script depends on the Python script [bump2version](https://pypi.org/project/bump2version/). The configuration file for `bump2version` is found in this repo at `./.bumpversion.cfg`.
+
+### `bump-version` Examples
+
+```shell
+$ ./scripts/bump-version.sh --help
+Usage: bump-version.sh [--dry-run] [PART]
+Arguments:
+  PART            The part of the semver version to bump: major, minor, or patch
+                  Default: patch
+Options:
+  -h | --help     Print this usage guide.
+  -d | --dry-run  Do a dry run and print what the version bump would do
+Note:
+  This script requires bump2version -- https://pypi.org/project/bump2version/
+
+$ ./scripts/bump-version.sh --dry-run
+/usr/local/bin/bump2version
+current_version=1.0.4
+new_version=1.0.5
+SUCCESS: Version is now set to 1.0.4.
+```

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+function help() {
+  cat <<EOF
+Usage: $(basename "${0}") [--dry-run] [PART]
+Arguments:
+  PART            The part of the semver version to bump: major, minor, or patch
+                  Default: patch
+Options:
+  -h | --help     Print this usage guide.
+  -d | --dry-run  Do a dry run and print what the version bump would do
+Note:
+  This script requires bump2version -- https://pypi.org/project/bump2version/
+
+EOF
+}
+
+PART=patch
+while [[ ${#} -gt 0 ]]; do
+  argument="${1}"
+  case ${argument} in
+    -h|--help)
+      help
+      exit 0
+      shift "${#}" ;; # past all remaining args
+    -d|--dry-run)
+      ARGUMENTS="--dry-run"
+      shift 1 ;;
+    major|minor|patch)
+      PART=${1}
+      shift 1 ;;
+    *)
+      remainder="${*}"
+      shift "${#}" ;; # past all remaining args
+  esac
+done
+
+
+# Check for bump2version and try to install if necessary
+if ! command -v bump2version; then
+  if ! pip install bump2version update -qq; then
+    >&2 echo "Failed to install bump2version. Do you even have pip installed?"
+  fi
+fi
+
+
+# Bump version
+if ! bump2version ${ARGUMENTS} --list --allow-dirty ${PART}; then
+  >&2 echo
+  >&2 echo "ERROR: Failed to bump version."
+else
+  echo "SUCCESS: Version is now set to $(cat ./VERSION)."
+fi


### PR DESCRIPTION
This PR does some things:

### Thing 1
Add a convenience version bumping script, `./scripts/bump-version.sh`, which relies on [bump2version](https://pypi.org/project/bump2version/). You need to run this manually. It's a little complicated adding this to the pipeline since bumping and pushing would trigger another build, which would bump and push, and so on!

### Thing 2
Fix the GitHub Actions workflow to successfully build and push the RPS Docker container using the convenience script, `./scripts/docker-build.sh`.

### Thing 3
Add some details to the README explaining the docker-build version-bump process.